### PR TITLE
Removed permit that doesn't appear needed but causes peculiar

### DIFF
--- a/lib/Data/DPath/Context.pm
+++ b/lib/Data/DPath/Context.pm
@@ -28,7 +28,6 @@ BEGIN {
 
         $COMPARTMENT = Safe->new;
         $COMPARTMENT->permit(qw":base_core");
-        $COMPARTMENT->permit(qw"require dofile caller runcv");
         $COMPARTMENT->reval( 'no warnings;' ); # just so warnings is loaded
         $COMPARTMENT->deny(qw"require dofile caller runcv");
         # map DPath filter functions into new namespace


### PR DESCRIPTION
warning:
"Number found where operator expected at {path}/warnings.pm line {line}, near "caller 1
when used in conjunction with Test::Exception.